### PR TITLE
arm: dts: qcom: msm8939: Move early-mount fstab to msm8939-common

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8939-common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8939-common.dtsi
@@ -112,6 +112,23 @@
 	};
 
 	soc: soc { };
+
+	firmware: firmware {
+		android {
+			compatible = "android,firmware";
+			fstab {
+				compatible = "android,fstab";
+				system {
+					compatible = "android,system";
+					dev = "/dev/block/platform/soc.0/7824900.sdhci/by-name/system";
+					type = "ext4";
+					mnt_flags = "ro,barrier=1,discard";
+					fsmgr_flags = "wait";
+					status = "ok";
+				};
+			};
+		};
+	};
 };
 
 #include "msm8939-ipcrouter.dtsi"

--- a/arch/arm/boot/dts/qcom/msm8939.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8939.dtsi
@@ -30,23 +30,6 @@
 	chosen {
 		bootargs = "boot_cpus=0,1,2,3,4,5,6,7 sched_enable_hmp=1 sched_enable_power_aware=1";
 	};
-
-        firmware: firmware {
-                 android {
-                         compatible = "android,firmware";
-                         fstab {
-                                 compatible = "android,fstab";
-                                 system {
-                                         compatible = "android,system";
-                                         dev = "/dev/block/platform/soc.0/7824900.sdhci/by-name/system";
-                                         type = "ext4";
-                                         mnt_flags = "ro,barrier=1,discard";
-                                         fsmgr_flags = "wait";
-                                         status = "ok";
-                                 };
-                         };
-                 };
-        };
 };
 
 &soc {


### PR DESCRIPTION
* Hopefully this should fix early-mount support on devices using
  msm8939-v3.0 dtsi like ido.

Change-Id: I40821bfcad7c0eb4580f14bab815f7b1781d45a1
Signed-off-by: Albert I <krascgq@outlook.co.id>